### PR TITLE
Title

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onewire"
-version = "0.3.13"
+version = "0.4.0"
 authors = ["Michael Watzko <michael@watzko.de>"]
 repository = "https://github.com/kellerkindt/onewire"
 description = "OneWire implementation using embedded_hal as abstraction layer, based on arduino OneWire library. WIP"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
+defmt = { version = "0.3.10", optional = true }
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/src/ds18b20.rs
+++ b/src/ds18b20.rs
@@ -49,7 +49,7 @@ pub struct DS18B20 {
 impl DS18B20 {
     pub fn new(device: Device) -> Result<DS18B20, Error<Infallible>> {
         if device.address[0] != FAMILY_CODE {
-            Err(Error::FamilyCodeMismatch(FAMILY_CODE, device.address[0]))
+            Err(Error::FamilyCodeMismatch { expected: FAMILY_CODE, actual: device.address[0] })
         } else {
             Ok(DS18B20 {
                 device,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,21 @@ impl<E: Sized + Debug> From<E> for Error<E> {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl<E: Sized + Debug> defmt::Format for Error<E> {
+    fn format(&self, fmt: defmt::Formatter) {
+        use defmt::write;
+        match self {
+            Error::WireNotHigh => write!(fmt, "WireNotHigh"),
+            Error::CrcMismatch { expected, computed } => write!(fmt, "CrcMismatch { expected: {:#04x}, computed: {:#04x} }", expected, computed),
+            Error::FamilyCodeMismatch { expected, actual } => write!(fmt, "FamilyCodeMismatch { expected: {:#04x}, actual: {:#04x} }", expected, actual),
+            Error::Debug(value) => write!(fmt, "Debug { value: {:#04x} }", value),
+            Error::PortError(e) => write!(fmt, "PortError { e: {:#?} }", e),
+        }
+    }
+}
+
+
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Device {
     pub address: [u8; ADDRESS_BYTES as usize],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,14 @@ pub enum Command {
 #[derive(Debug)]
 pub enum Error<E: Sized + Debug> {
     WireNotHigh,
-    CrcMismatch(u8, u8),
-    FamilyCodeMismatch(u8, u8),
+    CrcMismatch {
+        computed: u8,
+        expected: u8,
+    },
+    FamilyCodeMismatch {
+        expected: u8,
+        actual: u8,
+    },
     Debug(Option<u8>),
     PortError(E),
 }
@@ -573,7 +579,7 @@ pub fn ensure_correct_rcr8<E: Debug>(
 ) -> Result<(), Error<E>> {
     let computed = compute_crc8(device, data);
     if computed != crc8 {
-        Err(Error::CrcMismatch(computed, crc8))
+        Err(Error::CrcMismatch{ computed, expected: crc8 } )
     } else {
         Ok(())
     }


### PR DESCRIPTION
Add `defmt` support and refactor error variants

### Description

#### Changes Introduced
- Added an optional dependency on `defmt` to enhance embedded system support.
- Refactored error variants to use named fields, improving clarity and resolving ambiguity between multiple values.